### PR TITLE
Update 011_3_qubit_grover_50_.qasm

### DIFF
--- a/examples/ibmqx2/011_3_qubit_grover_50_.qasm
+++ b/examples/ibmqx2/011_3_qubit_grover_50_.qasm
@@ -5,7 +5,7 @@ OPENQASM 2.0;
 include "qelib1.inc";
 
 qreg q[5];
-creg c[5];
+creg c[3];
 
 h q[0];
 h q[1];


### PR DESCRIPTION
Bits c[3] and c[4] never used.